### PR TITLE
Fix fatal error on cron: support IndieAuth 4.x namespaced class

### DIFF
--- a/yarns-microsub.php
+++ b/yarns-microsub.php
@@ -48,6 +48,21 @@ class Yarns_MicroSub_Plugin {
 	public static $version = '1.1.0';
 
 	/**
+	 * Whether a compatible IndieAuth plugin is active.
+	 *
+	 * Older releases of the IndieAuth plugin exposed a global
+	 * `IndieAuth_Plugin` class. As of IndieAuth 4.x the plugin was
+	 * rewritten under the `IndieAuth` namespace and no longer defines
+	 * that class, so both are checked here to stay compatible with
+	 * old and new IndieAuth versions.
+	 *
+	 * @return bool
+	 */
+	public static function indieauth_active() {
+		return class_exists( 'IndieAuth_Plugin' ) || class_exists( '\IndieAuth\IndieAuth' );
+	}
+
+	/**
 	 * Run when plugins are loaded.
 	 */
 	public static function plugins_loaded() {
@@ -116,7 +131,7 @@ class Yarns_MicroSub_Plugin {
 	 */
 	public static function init() {
 
-		if ( ! class_exists( 'IndieAuth_Plugin' ) ) {
+		if ( ! self::indieauth_active() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'indieauth_not_installed_notice' ) );
 			return;
 		}
@@ -209,7 +224,7 @@ class Yarns_MicroSub_Plugin {
 	 * @return string
 	 */
 	public static function indieauth_plugin_notice() {
-		if ( ! class_exists( 'IndieAuth_Plugin' ) ) {
+		if ( ! self::indieauth_active() ) {
 			$class   = 'notice notice-error';
 			$message = __( '<b>Yarns Microsub Server notice:</b> WordPress IndieAuth Plugin is not active. Yarns Microsub Server requires this plugin to authorize microsub clients.', 'yarns-microsub-server' );
 			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), $message );


### PR DESCRIPTION
## Problem

`Yarns_MicroSub_Plugin::init()` gates all initialisation (including requiring `includes/class-yarns-microsub-aggregator.php`) behind:

```php
if ( ! class_exists( 'IndieAuth_Plugin' ) ) {
    ...
    return;
}
```

As of IndieAuth 4.x, the [IndieAuth plugin](https://github.com/indieweb/wordpress-indieauth) was rewritten under the `IndieAuth` namespace and no longer defines a global `IndieAuth_Plugin` class (it's now `IndieAuth\IndieAuth`). Against any current IndieAuth install, this check is always false, so `init()` bails out on every request — which means `Yarns_Microsub_Aggregator` never gets defined.

However, the cron hook is wired up unconditionally at file-load time, independent of `init()`:

```php
add_action( 'yarns_microsub_server_cron', array( 'Yarns_Microsub_Aggregator', 'poll' ) );
```

So every time the 15-minute cron fires, WordPress tries to invoke a class that was never loaded, producing a fatal error on every `wp-cron.php` run:

```
PHP Fatal error:  Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, class "Yarns_Microsub_Aggregator" not found in .../wp-includes/class-wp-hook.php:341
```

## Fix

Adds a small `Yarns_MicroSub_Plugin::indieauth_active()` helper that checks for either the legacy `IndieAuth_Plugin` class or the current `IndieAuth\IndieAuth` class, and uses it in both the `init()` guard and the admin notice. This restores compatibility with current IndieAuth releases while still supporting older ones.

Tested on a live multisite install running IndieAuth 4.7.0 — confirmed the fatal error on every cron cycle before the patch, and confirmed it's resolved after.